### PR TITLE
tests

### DIFF
--- a/Tests/Assert.h
+++ b/Tests/Assert.h
@@ -94,6 +94,23 @@ public:
 
 
 
+  void lt(const std::string& assertText, float tested, float correct){
+    total++;
+
+    if(tested >= correct){
+      printf("%s\n", assertText.c_str());
+      printf("Tested: %f\n", tested);
+      printf("Correct: %f\n", correct);
+      return;
+    }
+    else
+      passed++;
+  };
+
+
+
+
+
 
   void isNullptr(const std::string& assertText, const char* tested){
     total++;


### PR DESCRIPTION
This pull request significantly expands and refines the unit tests for the `Unordered_map` data structure, replacing a single basic test with a comprehensive suite that checks hash function distribution, initialization, destruction, and set/get operations. It also introduces a new assertion helper for floating-point comparisons.

**Testing improvements:**

* Replaced the old `simpleTest` with four targeted tests: `unorderedMapHashFun`, `unorderedMapInit`, `unorderedMapDestroy`, and `unorderedMapSetAndGet`, each focusing on a distinct aspect of the `Unordered_map` implementation. [[1]](diffhunk://#diff-a84e24198fca1be0f78fea654eccb4d33ca01c6419536ced75b6e261ecb1d76dL13-R19) [[2]](diffhunk://#diff-a84e24198fca1be0f78fea654eccb4d33ca01c6419536ced75b6e261ecb1d76dL29-R38) [[3]](diffhunk://#diff-a84e24198fca1be0f78fea654eccb4d33ca01c6419536ced75b6e261ecb1d76dL39-R142)
* Added a `randomString` utility function to generate random keys for more robust hash function and set/get tests.

**Assertion enhancements:**

* Introduced a new `Assert::lt` method for checking if a tested floating-point value is less than a threshold, used for validating hash distribution uniformity.

**Test coverage details:**

* [`unorderedMapHashFun`](diffhunk://#diff-a84e24198fca1be0f78fea654eccb4d33ca01c6419536ced75b6e261ecb1d76dL39-R142): Verifies that the hash function distributes keys uniformly across buckets using statistical checks.
* `unorderedMapInit` and `unorderedMapDestroy`: Confirm correct allocation and cleanup of internal data structures.
* [`unorderedMapSetAndGet`](diffhunk://#diff-a84e24198fca1be0f78fea654eccb4d33ca01c6419536ced75b6e261ecb1d76dL39-R142): Ensures that values set in the map can be retrieved correctly using their keys.